### PR TITLE
actions: Hide unsupported actions in prefs

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shutdown Timer GNOME Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-16 21:58+0200\n"
+"POT-Creation-Date: 2023-12-30 21:57+0100\n"
 "PO-Revision-Date: 2022-04-07 22:30+0200\n"
 "Last-Translator: Daniel Neumann\n"
 "Language-Team: CZECH <jiri.doubravsky@gmail.com>\n"
@@ -21,118 +21,118 @@ msgstr ""
 "X-Poedit-Basepath: ../../..\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: src/dbus-service/action.js:133
+#: src/dbus-service/action.js:152
 msgid "Suspend then Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:134
+#: src/dbus-service/action.js:153
 msgid "Hybrid Sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:135
+#: src/dbus-service/action.js:154
 msgid "Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:136
+#: src/dbus-service/action.js:155
 msgid "Halt"
 msgstr ""
 
-#: src/dbus-service/action.js:137
+#: src/dbus-service/action.js:156
 msgid "Suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:138
+#: src/dbus-service/action.js:157
 msgid "Power Off"
 msgstr ""
 
-#: src/dbus-service/action.js:139
+#: src/dbus-service/action.js:158
 msgid "Restart"
 msgstr ""
 
-#: src/dbus-service/action.js:140 src/ui/prefs.ui:239 src/ui/prefs.ui:442
+#: src/dbus-service/action.js:159 src/ui/prefs.ui:239 src/ui/prefs.ui:442
 msgid "Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:141
+#: src/dbus-service/action.js:160
 msgid "No Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:147
+#: src/dbus-service/action.js:166
 msgctxt "checktext"
 msgid "suspend then hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:148
+#: src/dbus-service/action.js:167
 msgctxt "checktext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:149
+#: src/dbus-service/action.js:168
 msgctxt "checktext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:150
+#: src/dbus-service/action.js:169
 msgctxt "checktext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:151
+#: src/dbus-service/action.js:170
 msgctxt "checktext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:152
+#: src/dbus-service/action.js:171
 msgctxt "checktext"
 msgid "shutdown"
 msgstr "vypnutí"
 
-#: src/dbus-service/action.js:153
+#: src/dbus-service/action.js:172
 msgctxt "checktext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:154
+#: src/dbus-service/action.js:173
 msgctxt "checktext"
 msgid "wakeup"
 msgstr ""
 
-#: src/dbus-service/action.js:160
+#: src/dbus-service/action.js:179
 msgctxt "untiltext"
 msgid "suspend and hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:161
+#: src/dbus-service/action.js:180
 msgctxt "untiltext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:162
+#: src/dbus-service/action.js:181
 msgctxt "untiltext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:163
+#: src/dbus-service/action.js:182
 msgctxt "untiltext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:164
+#: src/dbus-service/action.js:183
 msgctxt "untiltext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:165
+#: src/dbus-service/action.js:184
 msgctxt "untiltext"
 msgid "shutdown"
 msgstr "vypnutí"
 
-#: src/dbus-service/action.js:166
+#: src/dbus-service/action.js:185
 msgctxt "untiltext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:167
+#: src/dbus-service/action.js:186
 msgctxt "untiltext"
 msgid "wakeup"
 msgstr ""
@@ -149,33 +149,13 @@ msgstr ""
 msgid "Privileged script installation required!"
 msgstr ""
 
-#: src/dbus-service/install.js:32 src/modules/install.js:32
-msgid "START"
-msgstr ""
-
-#: src/dbus-service/install.js:42 src/modules/install.js:42
-msgid "END"
-msgstr ""
-
-#: src/dbus-service/install.js:44 src/modules/install.js:44
-msgid "FAIL"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "install"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "uninstall"
-msgstr ""
-
-#: src/dbus-service/timer.js:108
+#: src/dbus-service/timer.js:113
 #, javascript-format
 msgctxt "StartSchedulePopup"
 msgid "%s in %s"
 msgstr "%s in %s"
 
-#: src/dbus-service/timer.js:112 src/modules/menu-item.js:400
+#: src/dbus-service/timer.js:117 src/modules/menu-item.js:393
 #: src/modules/schedule-info.js:123
 #, javascript-format
 msgid "%s hour"
@@ -184,7 +164,7 @@ msgstr[0] "%s uro"
 msgstr[1] "%s uri"
 msgstr[2] "%s ur"
 
-#: src/dbus-service/timer.js:113 src/modules/menu-item.js:401
+#: src/dbus-service/timer.js:118 src/modules/menu-item.js:394
 #, javascript-format
 msgid "%s minute"
 msgid_plural "%s minutes"
@@ -192,26 +172,31 @@ msgstr[0] "%s minuto"
 msgstr[1] "%s minute"
 msgstr[2] "%s minut"
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Confirmation canceled"
 msgstr ""
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Shutdown Timer stopped"
 msgstr "Odpočítávání k vypnutí zastaveno"
 
-#: src/dbus-service/timer.js:160
+#: src/dbus-service/timer.js:165
 #, javascript-format
 msgid "Waiting for %s confirmation"
 msgstr ""
 
-#: src/dbus-service/timer.js:210
+#: src/dbus-service/timer.js:215
 #, javascript-format
 msgctxt "CheckCommand"
 msgid "%s aborted (Code: %s)"
 msgstr ""
 
-#: src/dbus-service/timer.js:252 src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:223
+#, javascript-format
+msgid "%s is not supported!"
+msgstr ""
+
+#: src/dbus-service/timer.js:262 src/dbus-service/timer.js:320
 #, javascript-format
 msgctxt "Error"
 msgid ""
@@ -219,36 +204,56 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/dbus-service/timer.js:252
+#: src/dbus-service/timer.js:262
 msgid "Wake action failed!"
 msgstr ""
 
-#: src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:320
 msgid "Root mode protection failed!"
 msgstr ""
 
-#: src/modules/menu-item.js:92 src/modules/menu-item.js:298
+#: src/modules/install.js:32
+msgid "START"
+msgstr ""
+
+#: src/modules/install.js:42
+msgid "END"
+msgstr ""
+
+#: src/modules/install.js:44
+msgid "FAIL"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "install"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "uninstall"
+msgstr ""
+
+#: src/modules/menu-item.js:85 src/modules/menu-item.js:291
 msgid "Shutdown Timer"
 msgstr "Odpočet k vypnutí"
 
-#: src/modules/menu-item.js:124
+#: src/modules/menu-item.js:117
 msgid "Settings"
 msgstr "Možnosti"
 
-#: src/modules/menu-item.js:278
+#: src/modules/menu-item.js:271
 msgid "now"
 msgstr ""
 
-#: src/modules/menu-item.js:301
+#: src/modules/menu-item.js:294
 msgid "Check {checktext} for {durationString}"
 msgstr ""
 
-#: src/modules/menu-item.js:358 src/modules/menu-item.js:397
+#: src/modules/menu-item.js:351 src/modules/menu-item.js:390
 msgctxt "absolute time notation"
 msgid "%a, %R"
 msgstr ""
 
-#: src/modules/menu-item.js:361
+#: src/modules/menu-item.js:354
 #, javascript-format
 msgid "%s hr"
 msgid_plural "%s hrs"
@@ -256,7 +261,7 @@ msgstr[0] "%s uro"
 msgstr[1] "%s uri"
 msgstr[2] "%s ur"
 
-#: src/modules/menu-item.js:362 src/modules/schedule-info.js:129
+#: src/modules/menu-item.js:355 src/modules/schedule-info.js:129
 #, javascript-format
 msgid "%s min"
 msgid_plural "%s mins"
@@ -264,18 +269,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/modules/menu-item.js:368
+#: src/modules/menu-item.js:361
 #, javascript-format
 msgid "%s (protect)"
 msgstr ""
 
-#: src/modules/menu-item.js:392
+#: src/modules/menu-item.js:385
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s at %s"
 msgstr ""
 
-#: src/modules/menu-item.js:393
+#: src/modules/menu-item.js:386
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s after %s"

--- a/po/de.po
+++ b/po/de.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shutdown Timer GNOME Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-16 21:58+0200\n"
+"POT-Creation-Date: 2023-12-30 21:57+0100\n"
 "PO-Revision-Date: 2022-12-28 18:38+0100\n"
 "Last-Translator: Daniel Neumann\n"
 "Language-Team: GERMAN Jonatan Zeidler <jonatan_zeidler@gmx.de>\n"
@@ -20,118 +20,118 @@ msgstr ""
 "X-Poedit-Basepath: ../../..\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: src/dbus-service/action.js:133
+#: src/dbus-service/action.js:152
 msgid "Suspend then Hibernate"
 msgstr "Progressiver Ruhezustand"
 
-#: src/dbus-service/action.js:134
+#: src/dbus-service/action.js:153
 msgid "Hybrid Sleep"
 msgstr "Hybrider Ruhezustand"
 
-#: src/dbus-service/action.js:135
+#: src/dbus-service/action.js:154
 msgid "Hibernate"
 msgstr "Tiefer Ruhezustand"
 
-#: src/dbus-service/action.js:136
+#: src/dbus-service/action.js:155
 msgid "Halt"
 msgstr "Anhalten"
 
-#: src/dbus-service/action.js:137
+#: src/dbus-service/action.js:156
 msgid "Suspend"
 msgstr "Ruhezustand"
 
-#: src/dbus-service/action.js:138
+#: src/dbus-service/action.js:157
 msgid "Power Off"
 msgstr "Ausschalten"
 
-#: src/dbus-service/action.js:139
+#: src/dbus-service/action.js:158
 msgid "Restart"
 msgstr "Neustart"
 
-#: src/dbus-service/action.js:140 src/ui/prefs.ui:239 src/ui/prefs.ui:442
+#: src/dbus-service/action.js:159 src/ui/prefs.ui:239 src/ui/prefs.ui:442
 msgid "Wake"
 msgstr "Wecker"
 
-#: src/dbus-service/action.js:141
+#: src/dbus-service/action.js:160
 msgid "No Wake"
 msgstr "Kein Wecken"
 
-#: src/dbus-service/action.js:147
+#: src/dbus-service/action.js:166
 msgctxt "checktext"
 msgid "suspend then hibernate"
 msgstr "progressiven Ruhezustand"
 
-#: src/dbus-service/action.js:148
+#: src/dbus-service/action.js:167
 msgctxt "checktext"
 msgid "hybrid sleep"
 msgstr "hybriden Ruhezustand"
 
-#: src/dbus-service/action.js:149
+#: src/dbus-service/action.js:168
 msgctxt "checktext"
 msgid "hibernate"
 msgstr "tiefen Ruhezustand"
 
-#: src/dbus-service/action.js:150
+#: src/dbus-service/action.js:169
 msgctxt "checktext"
 msgid "halt"
 msgstr "Anhalten"
 
-#: src/dbus-service/action.js:151
+#: src/dbus-service/action.js:170
 msgctxt "checktext"
 msgid "suspend"
 msgstr "Ruhezustand"
 
-#: src/dbus-service/action.js:152
+#: src/dbus-service/action.js:171
 msgctxt "checktext"
 msgid "shutdown"
 msgstr "Abschalten"
 
-#: src/dbus-service/action.js:153
+#: src/dbus-service/action.js:172
 msgctxt "checktext"
 msgid "reboot"
 msgstr "Neustart"
 
-#: src/dbus-service/action.js:154
+#: src/dbus-service/action.js:173
 msgctxt "checktext"
 msgid "wakeup"
 msgstr "Wecken"
 
-#: src/dbus-service/action.js:160
+#: src/dbus-service/action.js:179
 msgctxt "untiltext"
 msgid "suspend and hibernate"
 msgstr "progressiver Ruhezustand"
 
-#: src/dbus-service/action.js:161
+#: src/dbus-service/action.js:180
 msgctxt "untiltext"
 msgid "hybrid sleep"
 msgstr "hybrider Ruhezustand"
 
-#: src/dbus-service/action.js:162
+#: src/dbus-service/action.js:181
 msgctxt "untiltext"
 msgid "hibernate"
 msgstr "tiefer Ruhezustand"
 
-#: src/dbus-service/action.js:163
+#: src/dbus-service/action.js:182
 msgctxt "untiltext"
 msgid "halt"
 msgstr "Anhalten"
 
-#: src/dbus-service/action.js:164
+#: src/dbus-service/action.js:183
 msgctxt "untiltext"
 msgid "suspend"
 msgstr "Ruhezustand"
 
-#: src/dbus-service/action.js:165
+#: src/dbus-service/action.js:184
 msgctxt "untiltext"
 msgid "shutdown"
 msgstr "Abschalten"
 
-#: src/dbus-service/action.js:166
+#: src/dbus-service/action.js:185
 msgctxt "untiltext"
 msgid "reboot"
 msgstr "Neustart"
 
-#: src/dbus-service/action.js:167
+#: src/dbus-service/action.js:186
 msgctxt "untiltext"
 msgid "wakeup"
 msgstr "Wecken"
@@ -148,33 +148,13 @@ msgstr "ABBRUCH"
 msgid "Privileged script installation required!"
 msgstr "Installation des privilegierten Skriptes erforderlich!"
 
-#: src/dbus-service/install.js:32 src/modules/install.js:32
-msgid "START"
-msgstr "START"
-
-#: src/dbus-service/install.js:42 src/modules/install.js:42
-msgid "END"
-msgstr "ENDE"
-
-#: src/dbus-service/install.js:44 src/modules/install.js:44
-msgid "FAIL"
-msgstr "FEHLER"
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "install"
-msgstr "Installieren"
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "uninstall"
-msgstr "Deinstallieren"
-
-#: src/dbus-service/timer.js:108
+#: src/dbus-service/timer.js:113
 #, javascript-format
 msgctxt "StartSchedulePopup"
 msgid "%s in %s"
 msgstr "%s in %s"
 
-#: src/dbus-service/timer.js:112 src/modules/menu-item.js:400
+#: src/dbus-service/timer.js:117 src/modules/menu-item.js:393
 #: src/modules/schedule-info.js:123
 #, javascript-format
 msgid "%s hour"
@@ -182,33 +162,38 @@ msgid_plural "%s hours"
 msgstr[0] "%s Std."
 msgstr[1] "%s Stdn."
 
-#: src/dbus-service/timer.js:113 src/modules/menu-item.js:401
+#: src/dbus-service/timer.js:118 src/modules/menu-item.js:394
 #, javascript-format
 msgid "%s minute"
 msgid_plural "%s minutes"
 msgstr[0] "%s Minute"
 msgstr[1] "%s Minuten"
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Confirmation canceled"
 msgstr "Prüfung abgebrochen"
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Shutdown Timer stopped"
 msgstr "Ausschaltuhr gestoppt"
 
-#: src/dbus-service/timer.js:160
+#: src/dbus-service/timer.js:165
 #, javascript-format
 msgid "Waiting for %s confirmation"
 msgstr "Warte auf Bestätigung für %s"
 
-#: src/dbus-service/timer.js:210
+#: src/dbus-service/timer.js:215
 #, javascript-format
 msgctxt "CheckCommand"
 msgid "%s aborted (Code: %s)"
 msgstr "%s abgebrochen (Code: %s)"
 
-#: src/dbus-service/timer.js:252 src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:223
+#, javascript-format
+msgid "%s is not supported!"
+msgstr "%s nicht unterstüzt!"
+
+#: src/dbus-service/timer.js:262 src/dbus-service/timer.js:320
 #, javascript-format
 msgctxt "Error"
 msgid ""
@@ -216,61 +201,81 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/dbus-service/timer.js:252
+#: src/dbus-service/timer.js:262
 msgid "Wake action failed!"
 msgstr "Wecker-Befehl fehlgeschlagen!"
 
-#: src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:320
 msgid "Root mode protection failed!"
 msgstr "Root-Modus-Absicherung fehlgeschlagen!"
 
-#: src/modules/menu-item.js:92 src/modules/menu-item.js:298
+#: src/modules/install.js:32
+msgid "START"
+msgstr "START"
+
+#: src/modules/install.js:42
+msgid "END"
+msgstr "ENDE"
+
+#: src/modules/install.js:44
+msgid "FAIL"
+msgstr "FEHLER"
+
+#: src/modules/install.js:62
+msgid "install"
+msgstr "Installieren"
+
+#: src/modules/install.js:62
+msgid "uninstall"
+msgstr "Deinstallieren"
+
+#: src/modules/menu-item.js:85 src/modules/menu-item.js:291
 msgid "Shutdown Timer"
 msgstr "Ausschaltuhr"
 
-#: src/modules/menu-item.js:124
+#: src/modules/menu-item.js:117
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/modules/menu-item.js:278
+#: src/modules/menu-item.js:271
 msgid "now"
 msgstr "jetzt"
 
-#: src/modules/menu-item.js:301
+#: src/modules/menu-item.js:294
 msgid "Check {checktext} for {durationString}"
 msgstr "Prüfe {checktext} seit {durationString}"
 
-#: src/modules/menu-item.js:358 src/modules/menu-item.js:397
+#: src/modules/menu-item.js:351 src/modules/menu-item.js:390
 msgctxt "absolute time notation"
 msgid "%a, %R"
 msgstr ""
 
-#: src/modules/menu-item.js:361
+#: src/modules/menu-item.js:354
 #, javascript-format
 msgid "%s hr"
 msgid_plural "%s hrs"
 msgstr[0] "%s Std."
 msgstr[1] "%s Stdn."
 
-#: src/modules/menu-item.js:362 src/modules/schedule-info.js:129
+#: src/modules/menu-item.js:355 src/modules/schedule-info.js:129
 #, javascript-format
 msgid "%s min"
 msgid_plural "%s mins"
 msgstr[0] "%s Min."
 msgstr[1] "%s Min."
 
-#: src/modules/menu-item.js:368
+#: src/modules/menu-item.js:361
 #, javascript-format
 msgid "%s (protect)"
 msgstr "%s (sicher)"
 
-#: src/modules/menu-item.js:392
+#: src/modules/menu-item.js:385
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s at %s"
 msgstr "%s am %s"
 
-#: src/modules/menu-item.js:393
+#: src/modules/menu-item.js:386
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s after %s"

--- a/po/el.po
+++ b/po/el.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shutdown Timer GNOME Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-16 21:58+0200\n"
+"POT-Creation-Date: 2023-12-30 21:57+0100\n"
 "PO-Revision-Date: 2022-04-07 22:08+0200\n"
 "Last-Translator: Daniel Neumann\n"
 "Language-Team: \n"
@@ -20,118 +20,118 @@ msgstr ""
 "X-Poedit-Basepath: ../../..\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: src/dbus-service/action.js:133
+#: src/dbus-service/action.js:152
 msgid "Suspend then Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:134
+#: src/dbus-service/action.js:153
 msgid "Hybrid Sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:135
+#: src/dbus-service/action.js:154
 msgid "Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:136
+#: src/dbus-service/action.js:155
 msgid "Halt"
 msgstr ""
 
-#: src/dbus-service/action.js:137
+#: src/dbus-service/action.js:156
 msgid "Suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:138
+#: src/dbus-service/action.js:157
 msgid "Power Off"
 msgstr ""
 
-#: src/dbus-service/action.js:139
+#: src/dbus-service/action.js:158
 msgid "Restart"
 msgstr ""
 
-#: src/dbus-service/action.js:140 src/ui/prefs.ui:239 src/ui/prefs.ui:442
+#: src/dbus-service/action.js:159 src/ui/prefs.ui:239 src/ui/prefs.ui:442
 msgid "Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:141
+#: src/dbus-service/action.js:160
 msgid "No Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:147
+#: src/dbus-service/action.js:166
 msgctxt "checktext"
 msgid "suspend then hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:148
+#: src/dbus-service/action.js:167
 msgctxt "checktext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:149
+#: src/dbus-service/action.js:168
 msgctxt "checktext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:150
+#: src/dbus-service/action.js:169
 msgctxt "checktext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:151
+#: src/dbus-service/action.js:170
 msgctxt "checktext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:152
+#: src/dbus-service/action.js:171
 msgctxt "checktext"
 msgid "shutdown"
 msgstr "απενεργοποίηση"
 
-#: src/dbus-service/action.js:153
+#: src/dbus-service/action.js:172
 msgctxt "checktext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:154
+#: src/dbus-service/action.js:173
 msgctxt "checktext"
 msgid "wakeup"
 msgstr ""
 
-#: src/dbus-service/action.js:160
+#: src/dbus-service/action.js:179
 msgctxt "untiltext"
 msgid "suspend and hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:161
+#: src/dbus-service/action.js:180
 msgctxt "untiltext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:162
+#: src/dbus-service/action.js:181
 msgctxt "untiltext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:163
+#: src/dbus-service/action.js:182
 msgctxt "untiltext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:164
+#: src/dbus-service/action.js:183
 msgctxt "untiltext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:165
+#: src/dbus-service/action.js:184
 msgctxt "untiltext"
 msgid "shutdown"
 msgstr "απενεργοποίηση"
 
-#: src/dbus-service/action.js:166
+#: src/dbus-service/action.js:185
 msgctxt "untiltext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:167
+#: src/dbus-service/action.js:186
 msgctxt "untiltext"
 msgid "wakeup"
 msgstr ""
@@ -148,33 +148,13 @@ msgstr ""
 msgid "Privileged script installation required!"
 msgstr ""
 
-#: src/dbus-service/install.js:32 src/modules/install.js:32
-msgid "START"
-msgstr ""
-
-#: src/dbus-service/install.js:42 src/modules/install.js:42
-msgid "END"
-msgstr ""
-
-#: src/dbus-service/install.js:44 src/modules/install.js:44
-msgid "FAIL"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "install"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "uninstall"
-msgstr ""
-
-#: src/dbus-service/timer.js:108
+#: src/dbus-service/timer.js:113
 #, javascript-format
 msgctxt "StartSchedulePopup"
 msgid "%s in %s"
 msgstr "%s σε %s"
 
-#: src/dbus-service/timer.js:112 src/modules/menu-item.js:400
+#: src/dbus-service/timer.js:117 src/modules/menu-item.js:393
 #: src/modules/schedule-info.js:123
 #, javascript-format
 msgid "%s hour"
@@ -182,33 +162,38 @@ msgid_plural "%s hours"
 msgstr[0] "%s ώρα"
 msgstr[1] "%s ώρες"
 
-#: src/dbus-service/timer.js:113 src/modules/menu-item.js:401
+#: src/dbus-service/timer.js:118 src/modules/menu-item.js:394
 #, javascript-format
 msgid "%s minute"
 msgid_plural "%s minutes"
 msgstr[0] "%s λεπτό"
 msgstr[1] "%s λεπτά"
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Confirmation canceled"
 msgstr ""
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Shutdown Timer stopped"
 msgstr "Η Αυτόματη Απενεργοποίηση σταμάτησε"
 
-#: src/dbus-service/timer.js:160
+#: src/dbus-service/timer.js:165
 #, javascript-format
 msgid "Waiting for %s confirmation"
 msgstr ""
 
-#: src/dbus-service/timer.js:210
+#: src/dbus-service/timer.js:215
 #, javascript-format
 msgctxt "CheckCommand"
 msgid "%s aborted (Code: %s)"
 msgstr ""
 
-#: src/dbus-service/timer.js:252 src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:223
+#, javascript-format
+msgid "%s is not supported!"
+msgstr ""
+
+#: src/dbus-service/timer.js:262 src/dbus-service/timer.js:320
 #, javascript-format
 msgctxt "Error"
 msgid ""
@@ -216,61 +201,81 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/dbus-service/timer.js:252
+#: src/dbus-service/timer.js:262
 msgid "Wake action failed!"
 msgstr ""
 
-#: src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:320
 msgid "Root mode protection failed!"
 msgstr ""
 
-#: src/modules/menu-item.js:92 src/modules/menu-item.js:298
+#: src/modules/install.js:32
+msgid "START"
+msgstr ""
+
+#: src/modules/install.js:42
+msgid "END"
+msgstr ""
+
+#: src/modules/install.js:44
+msgid "FAIL"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "install"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "uninstall"
+msgstr ""
+
+#: src/modules/menu-item.js:85 src/modules/menu-item.js:291
 msgid "Shutdown Timer"
 msgstr "Αυτόματη Απενεργοποίηση "
 
-#: src/modules/menu-item.js:124
+#: src/modules/menu-item.js:117
 msgid "Settings"
 msgstr "Ρυθμίσεις"
 
-#: src/modules/menu-item.js:278
+#: src/modules/menu-item.js:271
 msgid "now"
 msgstr ""
 
-#: src/modules/menu-item.js:301
+#: src/modules/menu-item.js:294
 msgid "Check {checktext} for {durationString}"
 msgstr ""
 
-#: src/modules/menu-item.js:358 src/modules/menu-item.js:397
+#: src/modules/menu-item.js:351 src/modules/menu-item.js:390
 msgctxt "absolute time notation"
 msgid "%a, %R"
 msgstr ""
 
-#: src/modules/menu-item.js:361
+#: src/modules/menu-item.js:354
 #, javascript-format
 msgid "%s hr"
 msgid_plural "%s hrs"
 msgstr[0] "%s ώρα"
 msgstr[1] "%s ώρες"
 
-#: src/modules/menu-item.js:362 src/modules/schedule-info.js:129
+#: src/modules/menu-item.js:355 src/modules/schedule-info.js:129
 #, javascript-format
 msgid "%s min"
 msgid_plural "%s mins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/modules/menu-item.js:368
+#: src/modules/menu-item.js:361
 #, javascript-format
 msgid "%s (protect)"
 msgstr ""
 
-#: src/modules/menu-item.js:392
+#: src/modules/menu-item.js:385
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s at %s"
 msgstr ""
 
-#: src/modules/menu-item.js:393
+#: src/modules/menu-item.js:386
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s after %s"

--- a/po/es.po
+++ b/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shutdown Timer GNOME Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-16 21:58+0200\n"
+"POT-Creation-Date: 2023-12-30 21:57+0100\n"
 "PO-Revision-Date: 2022-04-07 22:06+0200\n"
 "Last-Translator: Daniel Neumann\n"
 "Language-Team: Jesús Ignacio García <jesusignazio@gmail.com>\n"
@@ -20,118 +20,118 @@ msgstr ""
 "X-Poedit-Basepath: ../../..\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: src/dbus-service/action.js:133
+#: src/dbus-service/action.js:152
 msgid "Suspend then Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:134
+#: src/dbus-service/action.js:153
 msgid "Hybrid Sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:135
+#: src/dbus-service/action.js:154
 msgid "Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:136
+#: src/dbus-service/action.js:155
 msgid "Halt"
 msgstr ""
 
-#: src/dbus-service/action.js:137
+#: src/dbus-service/action.js:156
 msgid "Suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:138
+#: src/dbus-service/action.js:157
 msgid "Power Off"
 msgstr ""
 
-#: src/dbus-service/action.js:139
+#: src/dbus-service/action.js:158
 msgid "Restart"
 msgstr ""
 
-#: src/dbus-service/action.js:140 src/ui/prefs.ui:239 src/ui/prefs.ui:442
+#: src/dbus-service/action.js:159 src/ui/prefs.ui:239 src/ui/prefs.ui:442
 msgid "Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:141
+#: src/dbus-service/action.js:160
 msgid "No Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:147
+#: src/dbus-service/action.js:166
 msgctxt "checktext"
 msgid "suspend then hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:148
+#: src/dbus-service/action.js:167
 msgctxt "checktext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:149
+#: src/dbus-service/action.js:168
 msgctxt "checktext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:150
+#: src/dbus-service/action.js:169
 msgctxt "checktext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:151
+#: src/dbus-service/action.js:170
 msgctxt "checktext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:152
+#: src/dbus-service/action.js:171
 msgctxt "checktext"
 msgid "shutdown"
 msgstr "apagado."
 
-#: src/dbus-service/action.js:153
+#: src/dbus-service/action.js:172
 msgctxt "checktext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:154
+#: src/dbus-service/action.js:173
 msgctxt "checktext"
 msgid "wakeup"
 msgstr ""
 
-#: src/dbus-service/action.js:160
+#: src/dbus-service/action.js:179
 msgctxt "untiltext"
 msgid "suspend and hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:161
+#: src/dbus-service/action.js:180
 msgctxt "untiltext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:162
+#: src/dbus-service/action.js:181
 msgctxt "untiltext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:163
+#: src/dbus-service/action.js:182
 msgctxt "untiltext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:164
+#: src/dbus-service/action.js:183
 msgctxt "untiltext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:165
+#: src/dbus-service/action.js:184
 msgctxt "untiltext"
 msgid "shutdown"
 msgstr "apagado."
 
-#: src/dbus-service/action.js:166
+#: src/dbus-service/action.js:185
 msgctxt "untiltext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:167
+#: src/dbus-service/action.js:186
 msgctxt "untiltext"
 msgid "wakeup"
 msgstr ""
@@ -148,33 +148,13 @@ msgstr ""
 msgid "Privileged script installation required!"
 msgstr ""
 
-#: src/dbus-service/install.js:32 src/modules/install.js:32
-msgid "START"
-msgstr ""
-
-#: src/dbus-service/install.js:42 src/modules/install.js:42
-msgid "END"
-msgstr ""
-
-#: src/dbus-service/install.js:44 src/modules/install.js:44
-msgid "FAIL"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "install"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "uninstall"
-msgstr ""
-
-#: src/dbus-service/timer.js:108
+#: src/dbus-service/timer.js:113
 #, javascript-format
 msgctxt "StartSchedulePopup"
 msgid "%s in %s"
 msgstr "%s en %s"
 
-#: src/dbus-service/timer.js:112 src/modules/menu-item.js:400
+#: src/dbus-service/timer.js:117 src/modules/menu-item.js:393
 #: src/modules/schedule-info.js:123
 #, javascript-format
 msgid "%s hour"
@@ -182,33 +162,38 @@ msgid_plural "%s hours"
 msgstr[0] "%s hora"
 msgstr[1] "%s horas"
 
-#: src/dbus-service/timer.js:113 src/modules/menu-item.js:401
+#: src/dbus-service/timer.js:118 src/modules/menu-item.js:394
 #, javascript-format
 msgid "%s minute"
 msgid_plural "%s minutes"
 msgstr[0] "%s minuto"
 msgstr[1] "%s minutos"
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Confirmation canceled"
 msgstr ""
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Shutdown Timer stopped"
 msgstr "Temporizador apagado."
 
-#: src/dbus-service/timer.js:160
+#: src/dbus-service/timer.js:165
 #, javascript-format
 msgid "Waiting for %s confirmation"
 msgstr ""
 
-#: src/dbus-service/timer.js:210
+#: src/dbus-service/timer.js:215
 #, javascript-format
 msgctxt "CheckCommand"
 msgid "%s aborted (Code: %s)"
 msgstr ""
 
-#: src/dbus-service/timer.js:252 src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:223
+#, javascript-format
+msgid "%s is not supported!"
+msgstr ""
+
+#: src/dbus-service/timer.js:262 src/dbus-service/timer.js:320
 #, javascript-format
 msgctxt "Error"
 msgid ""
@@ -216,61 +201,81 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/dbus-service/timer.js:252
+#: src/dbus-service/timer.js:262
 msgid "Wake action failed!"
 msgstr ""
 
-#: src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:320
 msgid "Root mode protection failed!"
 msgstr ""
 
-#: src/modules/menu-item.js:92 src/modules/menu-item.js:298
+#: src/modules/install.js:32
+msgid "START"
+msgstr ""
+
+#: src/modules/install.js:42
+msgid "END"
+msgstr ""
+
+#: src/modules/install.js:44
+msgid "FAIL"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "install"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "uninstall"
+msgstr ""
+
+#: src/modules/menu-item.js:85 src/modules/menu-item.js:291
 msgid "Shutdown Timer"
 msgstr "Apagar con temporizador."
 
-#: src/modules/menu-item.js:124
+#: src/modules/menu-item.js:117
 msgid "Settings"
 msgstr ""
 
-#: src/modules/menu-item.js:278
+#: src/modules/menu-item.js:271
 msgid "now"
 msgstr ""
 
-#: src/modules/menu-item.js:301
+#: src/modules/menu-item.js:294
 msgid "Check {checktext} for {durationString}"
 msgstr ""
 
-#: src/modules/menu-item.js:358 src/modules/menu-item.js:397
+#: src/modules/menu-item.js:351 src/modules/menu-item.js:390
 msgctxt "absolute time notation"
 msgid "%a, %R"
 msgstr ""
 
-#: src/modules/menu-item.js:361
+#: src/modules/menu-item.js:354
 #, javascript-format
 msgid "%s hr"
 msgid_plural "%s hrs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/modules/menu-item.js:362 src/modules/schedule-info.js:129
+#: src/modules/menu-item.js:355 src/modules/schedule-info.js:129
 #, javascript-format
 msgid "%s min"
 msgid_plural "%s mins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/modules/menu-item.js:368
+#: src/modules/menu-item.js:361
 #, javascript-format
 msgid "%s (protect)"
 msgstr ""
 
-#: src/modules/menu-item.js:392
+#: src/modules/menu-item.js:385
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s at %s"
 msgstr ""
 
-#: src/modules/menu-item.js:393
+#: src/modules/menu-item.js:386
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s after %s"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shutdown Timer GNOME Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-16 21:58+0200\n"
+"POT-Creation-Date: 2023-12-30 21:57+0100\n"
 "PO-Revision-Date: 2022-04-07 22:25+0200\n"
 "Last-Translator: Brendan Chabannes <brendan.chabannes@gmail.com>\n"
 "Language-Team: \n"
@@ -20,118 +20,118 @@ msgstr ""
 "X-Poedit-Basepath: ../../..\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: src/dbus-service/action.js:133
+#: src/dbus-service/action.js:152
 msgid "Suspend then Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:134
+#: src/dbus-service/action.js:153
 msgid "Hybrid Sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:135
+#: src/dbus-service/action.js:154
 msgid "Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:136
+#: src/dbus-service/action.js:155
 msgid "Halt"
 msgstr ""
 
-#: src/dbus-service/action.js:137
+#: src/dbus-service/action.js:156
 msgid "Suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:138
+#: src/dbus-service/action.js:157
 msgid "Power Off"
 msgstr ""
 
-#: src/dbus-service/action.js:139
+#: src/dbus-service/action.js:158
 msgid "Restart"
 msgstr ""
 
-#: src/dbus-service/action.js:140 src/ui/prefs.ui:239 src/ui/prefs.ui:442
+#: src/dbus-service/action.js:159 src/ui/prefs.ui:239 src/ui/prefs.ui:442
 msgid "Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:141
+#: src/dbus-service/action.js:160
 msgid "No Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:147
+#: src/dbus-service/action.js:166
 msgctxt "checktext"
 msgid "suspend then hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:148
+#: src/dbus-service/action.js:167
 msgctxt "checktext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:149
+#: src/dbus-service/action.js:168
 msgctxt "checktext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:150
+#: src/dbus-service/action.js:169
 msgctxt "checktext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:151
+#: src/dbus-service/action.js:170
 msgctxt "checktext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:152
+#: src/dbus-service/action.js:171
 msgctxt "checktext"
 msgid "shutdown"
 msgstr "arrêt"
 
-#: src/dbus-service/action.js:153
+#: src/dbus-service/action.js:172
 msgctxt "checktext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:154
+#: src/dbus-service/action.js:173
 msgctxt "checktext"
 msgid "wakeup"
 msgstr ""
 
-#: src/dbus-service/action.js:160
+#: src/dbus-service/action.js:179
 msgctxt "untiltext"
 msgid "suspend and hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:161
+#: src/dbus-service/action.js:180
 msgctxt "untiltext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:162
+#: src/dbus-service/action.js:181
 msgctxt "untiltext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:163
+#: src/dbus-service/action.js:182
 msgctxt "untiltext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:164
+#: src/dbus-service/action.js:183
 msgctxt "untiltext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:165
+#: src/dbus-service/action.js:184
 msgctxt "untiltext"
 msgid "shutdown"
 msgstr "arrêt"
 
-#: src/dbus-service/action.js:166
+#: src/dbus-service/action.js:185
 msgctxt "untiltext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:167
+#: src/dbus-service/action.js:186
 msgctxt "untiltext"
 msgid "wakeup"
 msgstr ""
@@ -148,33 +148,13 @@ msgstr ""
 msgid "Privileged script installation required!"
 msgstr ""
 
-#: src/dbus-service/install.js:32 src/modules/install.js:32
-msgid "START"
-msgstr ""
-
-#: src/dbus-service/install.js:42 src/modules/install.js:42
-msgid "END"
-msgstr ""
-
-#: src/dbus-service/install.js:44 src/modules/install.js:44
-msgid "FAIL"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "install"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "uninstall"
-msgstr ""
-
-#: src/dbus-service/timer.js:108
+#: src/dbus-service/timer.js:113
 #, javascript-format
 msgctxt "StartSchedulePopup"
 msgid "%s in %s"
 msgstr "%s dans %s"
 
-#: src/dbus-service/timer.js:112 src/modules/menu-item.js:400
+#: src/dbus-service/timer.js:117 src/modules/menu-item.js:393
 #: src/modules/schedule-info.js:123
 #, javascript-format
 msgid "%s hour"
@@ -182,33 +162,38 @@ msgid_plural "%s hours"
 msgstr[0] "%s heure"
 msgstr[1] "%s heures"
 
-#: src/dbus-service/timer.js:113 src/modules/menu-item.js:401
+#: src/dbus-service/timer.js:118 src/modules/menu-item.js:394
 #, javascript-format
 msgid "%s minute"
 msgid_plural "%s minutes"
 msgstr[0] "%s minute"
 msgstr[1] "%s minutes"
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Confirmation canceled"
 msgstr ""
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Shutdown Timer stopped"
 msgstr "Le décompte avant extinction s’est arrêté"
 
-#: src/dbus-service/timer.js:160
+#: src/dbus-service/timer.js:165
 #, javascript-format
 msgid "Waiting for %s confirmation"
 msgstr ""
 
-#: src/dbus-service/timer.js:210
+#: src/dbus-service/timer.js:215
 #, javascript-format
 msgctxt "CheckCommand"
 msgid "%s aborted (Code: %s)"
 msgstr ""
 
-#: src/dbus-service/timer.js:252 src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:223
+#, javascript-format
+msgid "%s is not supported!"
+msgstr ""
+
+#: src/dbus-service/timer.js:262 src/dbus-service/timer.js:320
 #, javascript-format
 msgctxt "Error"
 msgid ""
@@ -216,61 +201,81 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/dbus-service/timer.js:252
+#: src/dbus-service/timer.js:262
 msgid "Wake action failed!"
 msgstr ""
 
-#: src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:320
 msgid "Root mode protection failed!"
 msgstr ""
 
-#: src/modules/menu-item.js:92 src/modules/menu-item.js:298
+#: src/modules/install.js:32
+msgid "START"
+msgstr ""
+
+#: src/modules/install.js:42
+msgid "END"
+msgstr ""
+
+#: src/modules/install.js:44
+msgid "FAIL"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "install"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "uninstall"
+msgstr ""
+
+#: src/modules/menu-item.js:85 src/modules/menu-item.js:291
 msgid "Shutdown Timer"
 msgstr "Arrêt planifié"
 
-#: src/modules/menu-item.js:124
+#: src/modules/menu-item.js:117
 msgid "Settings"
 msgstr "Préférences"
 
-#: src/modules/menu-item.js:278
+#: src/modules/menu-item.js:271
 msgid "now"
 msgstr ""
 
-#: src/modules/menu-item.js:301
+#: src/modules/menu-item.js:294
 msgid "Check {checktext} for {durationString}"
 msgstr ""
 
-#: src/modules/menu-item.js:358 src/modules/menu-item.js:397
+#: src/modules/menu-item.js:351 src/modules/menu-item.js:390
 msgctxt "absolute time notation"
 msgid "%a, %R"
 msgstr ""
 
-#: src/modules/menu-item.js:361
+#: src/modules/menu-item.js:354
 #, javascript-format
 msgid "%s hr"
 msgid_plural "%s hrs"
 msgstr[0] "%s h"
 msgstr[1] "%s h"
 
-#: src/modules/menu-item.js:362 src/modules/schedule-info.js:129
+#: src/modules/menu-item.js:355 src/modules/schedule-info.js:129
 #, javascript-format
 msgid "%s min"
 msgid_plural "%s mins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/modules/menu-item.js:368
+#: src/modules/menu-item.js:361
 #, javascript-format
 msgid "%s (protect)"
 msgstr ""
 
-#: src/modules/menu-item.js:392
+#: src/modules/menu-item.js:385
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s at %s"
 msgstr ""
 
-#: src/modules/menu-item.js:393
+#: src/modules/menu-item.js:386
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s after %s"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shutdown Timer GNOME Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-16 21:58+0200\n"
+"POT-Creation-Date: 2023-12-30 21:57+0100\n"
 "PO-Revision-Date: 2022-11-01 23:29+0100\n"
 "Last-Translator: Gianni Lerro <squall77it@gmail.com>\n"
 "Language-Team: Italiano <>\n"
@@ -21,118 +21,118 @@ msgstr ""
 "X-Poedit-Basepath: ../../..\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: src/dbus-service/action.js:133
+#: src/dbus-service/action.js:152
 msgid "Suspend then Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:134
+#: src/dbus-service/action.js:153
 msgid "Hybrid Sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:135
+#: src/dbus-service/action.js:154
 msgid "Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:136
+#: src/dbus-service/action.js:155
 msgid "Halt"
 msgstr ""
 
-#: src/dbus-service/action.js:137
+#: src/dbus-service/action.js:156
 msgid "Suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:138
+#: src/dbus-service/action.js:157
 msgid "Power Off"
 msgstr ""
 
-#: src/dbus-service/action.js:139
+#: src/dbus-service/action.js:158
 msgid "Restart"
 msgstr ""
 
-#: src/dbus-service/action.js:140 src/ui/prefs.ui:239 src/ui/prefs.ui:442
+#: src/dbus-service/action.js:159 src/ui/prefs.ui:239 src/ui/prefs.ui:442
 msgid "Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:141
+#: src/dbus-service/action.js:160
 msgid "No Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:147
+#: src/dbus-service/action.js:166
 msgctxt "checktext"
 msgid "suspend then hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:148
+#: src/dbus-service/action.js:167
 msgctxt "checktext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:149
+#: src/dbus-service/action.js:168
 msgctxt "checktext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:150
+#: src/dbus-service/action.js:169
 msgctxt "checktext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:151
+#: src/dbus-service/action.js:170
 msgctxt "checktext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:152
+#: src/dbus-service/action.js:171
 msgctxt "checktext"
 msgid "shutdown"
 msgstr "spegnimento"
 
-#: src/dbus-service/action.js:153
+#: src/dbus-service/action.js:172
 msgctxt "checktext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:154
+#: src/dbus-service/action.js:173
 msgctxt "checktext"
 msgid "wakeup"
 msgstr ""
 
-#: src/dbus-service/action.js:160
+#: src/dbus-service/action.js:179
 msgctxt "untiltext"
 msgid "suspend and hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:161
+#: src/dbus-service/action.js:180
 msgctxt "untiltext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:162
+#: src/dbus-service/action.js:181
 msgctxt "untiltext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:163
+#: src/dbus-service/action.js:182
 msgctxt "untiltext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:164
+#: src/dbus-service/action.js:183
 msgctxt "untiltext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:165
+#: src/dbus-service/action.js:184
 msgctxt "untiltext"
 msgid "shutdown"
 msgstr "spegnimento"
 
-#: src/dbus-service/action.js:166
+#: src/dbus-service/action.js:185
 msgctxt "untiltext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:167
+#: src/dbus-service/action.js:186
 msgctxt "untiltext"
 msgid "wakeup"
 msgstr ""
@@ -149,33 +149,13 @@ msgstr ""
 msgid "Privileged script installation required!"
 msgstr ""
 
-#: src/dbus-service/install.js:32 src/modules/install.js:32
-msgid "START"
-msgstr ""
-
-#: src/dbus-service/install.js:42 src/modules/install.js:42
-msgid "END"
-msgstr ""
-
-#: src/dbus-service/install.js:44 src/modules/install.js:44
-msgid "FAIL"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "install"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "uninstall"
-msgstr ""
-
-#: src/dbus-service/timer.js:108
+#: src/dbus-service/timer.js:113
 #, javascript-format
 msgctxt "StartSchedulePopup"
 msgid "%s in %s"
 msgstr "%s in %s"
 
-#: src/dbus-service/timer.js:112 src/modules/menu-item.js:400
+#: src/dbus-service/timer.js:117 src/modules/menu-item.js:393
 #: src/modules/schedule-info.js:123
 #, javascript-format
 msgid "%s hour"
@@ -183,33 +163,38 @@ msgid_plural "%s hours"
 msgstr[0] "%s ora"
 msgstr[1] "%s ore"
 
-#: src/dbus-service/timer.js:113 src/modules/menu-item.js:401
+#: src/dbus-service/timer.js:118 src/modules/menu-item.js:394
 #, javascript-format
 msgid "%s minute"
 msgid_plural "%s minutes"
 msgstr[0] "%s minuta"
 msgstr[1] "%s minuti"
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Confirmation canceled"
 msgstr ""
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Shutdown Timer stopped"
 msgstr "Timer di spegnimento interrotto"
 
-#: src/dbus-service/timer.js:160
+#: src/dbus-service/timer.js:165
 #, javascript-format
 msgid "Waiting for %s confirmation"
 msgstr ""
 
-#: src/dbus-service/timer.js:210
+#: src/dbus-service/timer.js:215
 #, javascript-format
 msgctxt "CheckCommand"
 msgid "%s aborted (Code: %s)"
 msgstr ""
 
-#: src/dbus-service/timer.js:252 src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:223
+#, javascript-format
+msgid "%s is not supported!"
+msgstr ""
+
+#: src/dbus-service/timer.js:262 src/dbus-service/timer.js:320
 #, javascript-format
 msgctxt "Error"
 msgid ""
@@ -217,61 +202,81 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/dbus-service/timer.js:252
+#: src/dbus-service/timer.js:262
 msgid "Wake action failed!"
 msgstr ""
 
-#: src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:320
 msgid "Root mode protection failed!"
 msgstr ""
 
-#: src/modules/menu-item.js:92 src/modules/menu-item.js:298
+#: src/modules/install.js:32
+msgid "START"
+msgstr ""
+
+#: src/modules/install.js:42
+msgid "END"
+msgstr ""
+
+#: src/modules/install.js:44
+msgid "FAIL"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "install"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "uninstall"
+msgstr ""
+
+#: src/modules/menu-item.js:85 src/modules/menu-item.js:291
 msgid "Shutdown Timer"
 msgstr "Timer di spegnimento"
 
-#: src/modules/menu-item.js:124
+#: src/modules/menu-item.js:117
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: src/modules/menu-item.js:278
+#: src/modules/menu-item.js:271
 msgid "now"
 msgstr ""
 
-#: src/modules/menu-item.js:301
+#: src/modules/menu-item.js:294
 msgid "Check {checktext} for {durationString}"
 msgstr ""
 
-#: src/modules/menu-item.js:358 src/modules/menu-item.js:397
+#: src/modules/menu-item.js:351 src/modules/menu-item.js:390
 msgctxt "absolute time notation"
 msgid "%a, %R"
 msgstr ""
 
-#: src/modules/menu-item.js:361
+#: src/modules/menu-item.js:354
 #, javascript-format
 msgid "%s hr"
 msgid_plural "%s hrs"
 msgstr[0] "%s ora"
 msgstr[1] "%s ore"
 
-#: src/modules/menu-item.js:362 src/modules/schedule-info.js:129
+#: src/modules/menu-item.js:355 src/modules/schedule-info.js:129
 #, javascript-format
 msgid "%s min"
 msgid_plural "%s mins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/modules/menu-item.js:368
+#: src/modules/menu-item.js:361
 #, javascript-format
 msgid "%s (protect)"
 msgstr ""
 
-#: src/modules/menu-item.js:392
+#: src/modules/menu-item.js:385
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s at %s"
 msgstr ""
 
-#: src/modules/menu-item.js:393
+#: src/modules/menu-item.js:386
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s after %s"

--- a/po/main.pot
+++ b/po/main.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Shutdown Timer 38\n"
+"Project-Id-Version: Shutdown Timer 39\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-16 21:58+0200\n"
+"POT-Creation-Date: 2023-12-30 21:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,118 +18,118 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: src/dbus-service/action.js:133
+#: src/dbus-service/action.js:152
 msgid "Suspend then Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:134
+#: src/dbus-service/action.js:153
 msgid "Hybrid Sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:135
+#: src/dbus-service/action.js:154
 msgid "Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:136
+#: src/dbus-service/action.js:155
 msgid "Halt"
 msgstr ""
 
-#: src/dbus-service/action.js:137
+#: src/dbus-service/action.js:156
 msgid "Suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:138
+#: src/dbus-service/action.js:157
 msgid "Power Off"
 msgstr ""
 
-#: src/dbus-service/action.js:139
+#: src/dbus-service/action.js:158
 msgid "Restart"
 msgstr ""
 
-#: src/dbus-service/action.js:140 src/ui/prefs.ui:239 src/ui/prefs.ui:442
+#: src/dbus-service/action.js:159 src/ui/prefs.ui:239 src/ui/prefs.ui:442
 msgid "Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:141
+#: src/dbus-service/action.js:160
 msgid "No Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:147
+#: src/dbus-service/action.js:166
 msgctxt "checktext"
 msgid "suspend then hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:148
+#: src/dbus-service/action.js:167
 msgctxt "checktext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:149
+#: src/dbus-service/action.js:168
 msgctxt "checktext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:150
+#: src/dbus-service/action.js:169
 msgctxt "checktext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:151
+#: src/dbus-service/action.js:170
 msgctxt "checktext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:152
+#: src/dbus-service/action.js:171
 msgctxt "checktext"
 msgid "shutdown"
 msgstr ""
 
-#: src/dbus-service/action.js:153
+#: src/dbus-service/action.js:172
 msgctxt "checktext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:154
+#: src/dbus-service/action.js:173
 msgctxt "checktext"
 msgid "wakeup"
 msgstr ""
 
-#: src/dbus-service/action.js:160
+#: src/dbus-service/action.js:179
 msgctxt "untiltext"
 msgid "suspend and hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:161
+#: src/dbus-service/action.js:180
 msgctxt "untiltext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:162
+#: src/dbus-service/action.js:181
 msgctxt "untiltext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:163
+#: src/dbus-service/action.js:182
 msgctxt "untiltext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:164
+#: src/dbus-service/action.js:183
 msgctxt "untiltext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:165
+#: src/dbus-service/action.js:184
 msgctxt "untiltext"
 msgid "shutdown"
 msgstr ""
 
-#: src/dbus-service/action.js:166
+#: src/dbus-service/action.js:185
 msgctxt "untiltext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:167
+#: src/dbus-service/action.js:186
 msgctxt "untiltext"
 msgid "wakeup"
 msgstr ""
@@ -146,33 +146,13 @@ msgstr ""
 msgid "Privileged script installation required!"
 msgstr ""
 
-#: src/dbus-service/install.js:32 src/modules/install.js:32
-msgid "START"
-msgstr ""
-
-#: src/dbus-service/install.js:42 src/modules/install.js:42
-msgid "END"
-msgstr ""
-
-#: src/dbus-service/install.js:44 src/modules/install.js:44
-msgid "FAIL"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "install"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "uninstall"
-msgstr ""
-
-#: src/dbus-service/timer.js:108
+#: src/dbus-service/timer.js:113
 #, javascript-format
 msgctxt "StartSchedulePopup"
 msgid "%s in %s"
 msgstr ""
 
-#: src/dbus-service/timer.js:112 src/modules/menu-item.js:400
+#: src/dbus-service/timer.js:117 src/modules/menu-item.js:393
 #: src/modules/schedule-info.js:123
 #, javascript-format
 msgid "%s hour"
@@ -180,33 +160,38 @@ msgid_plural "%s hours"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/dbus-service/timer.js:113 src/modules/menu-item.js:401
+#: src/dbus-service/timer.js:118 src/modules/menu-item.js:394
 #, javascript-format
 msgid "%s minute"
 msgid_plural "%s minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Confirmation canceled"
 msgstr ""
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Shutdown Timer stopped"
 msgstr ""
 
-#: src/dbus-service/timer.js:160
+#: src/dbus-service/timer.js:165
 #, javascript-format
 msgid "Waiting for %s confirmation"
 msgstr ""
 
-#: src/dbus-service/timer.js:210
+#: src/dbus-service/timer.js:215
 #, javascript-format
 msgctxt "CheckCommand"
 msgid "%s aborted (Code: %s)"
 msgstr ""
 
-#: src/dbus-service/timer.js:252 src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:223
+#, javascript-format
+msgid "%s is not supported!"
+msgstr ""
+
+#: src/dbus-service/timer.js:262 src/dbus-service/timer.js:320
 #, javascript-format
 msgctxt "Error"
 msgid ""
@@ -214,61 +199,81 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/dbus-service/timer.js:252
+#: src/dbus-service/timer.js:262
 msgid "Wake action failed!"
 msgstr ""
 
-#: src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:320
 msgid "Root mode protection failed!"
 msgstr ""
 
-#: src/modules/menu-item.js:92 src/modules/menu-item.js:298
+#: src/modules/install.js:32
+msgid "START"
+msgstr ""
+
+#: src/modules/install.js:42
+msgid "END"
+msgstr ""
+
+#: src/modules/install.js:44
+msgid "FAIL"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "install"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "uninstall"
+msgstr ""
+
+#: src/modules/menu-item.js:85 src/modules/menu-item.js:291
 msgid "Shutdown Timer"
 msgstr ""
 
-#: src/modules/menu-item.js:124
+#: src/modules/menu-item.js:117
 msgid "Settings"
 msgstr ""
 
-#: src/modules/menu-item.js:278
+#: src/modules/menu-item.js:271
 msgid "now"
 msgstr ""
 
-#: src/modules/menu-item.js:301
+#: src/modules/menu-item.js:294
 msgid "Check {checktext} for {durationString}"
 msgstr ""
 
-#: src/modules/menu-item.js:358 src/modules/menu-item.js:397
+#: src/modules/menu-item.js:351 src/modules/menu-item.js:390
 msgctxt "absolute time notation"
 msgid "%a, %R"
 msgstr ""
 
-#: src/modules/menu-item.js:361
+#: src/modules/menu-item.js:354
 #, javascript-format
 msgid "%s hr"
 msgid_plural "%s hrs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/modules/menu-item.js:362 src/modules/schedule-info.js:129
+#: src/modules/menu-item.js:355 src/modules/schedule-info.js:129
 #, javascript-format
 msgid "%s min"
 msgid_plural "%s mins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/modules/menu-item.js:368
+#: src/modules/menu-item.js:361
 #, javascript-format
 msgid "%s (protect)"
 msgstr ""
 
-#: src/modules/menu-item.js:392
+#: src/modules/menu-item.js:385
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s at %s"
 msgstr ""
 
-#: src/modules/menu-item.js:393
+#: src/modules/menu-item.js:386
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s after %s"

--- a/po/nl.po
+++ b/po/nl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shutdown Timer GNOME Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-16 21:58+0200\n"
+"POT-Creation-Date: 2023-12-30 21:57+0100\n"
 "PO-Revision-Date: 2022-11-01 23:29+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch\n"
@@ -20,118 +20,118 @@ msgstr ""
 "X-Poedit-Basepath: ../../..\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: src/dbus-service/action.js:133
+#: src/dbus-service/action.js:152
 msgid "Suspend then Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:134
+#: src/dbus-service/action.js:153
 msgid "Hybrid Sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:135
+#: src/dbus-service/action.js:154
 msgid "Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:136
+#: src/dbus-service/action.js:155
 msgid "Halt"
 msgstr ""
 
-#: src/dbus-service/action.js:137
+#: src/dbus-service/action.js:156
 msgid "Suspend"
 msgstr "Pauzestand"
 
-#: src/dbus-service/action.js:138
+#: src/dbus-service/action.js:157
 msgid "Power Off"
 msgstr ""
 
-#: src/dbus-service/action.js:139
+#: src/dbus-service/action.js:158
 msgid "Restart"
 msgstr ""
 
-#: src/dbus-service/action.js:140 src/ui/prefs.ui:239 src/ui/prefs.ui:442
+#: src/dbus-service/action.js:159 src/ui/prefs.ui:239 src/ui/prefs.ui:442
 msgid "Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:141
+#: src/dbus-service/action.js:160
 msgid "No Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:147
+#: src/dbus-service/action.js:166
 msgctxt "checktext"
 msgid "suspend then hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:148
+#: src/dbus-service/action.js:167
 msgctxt "checktext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:149
+#: src/dbus-service/action.js:168
 msgctxt "checktext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:150
+#: src/dbus-service/action.js:169
 msgctxt "checktext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:151
+#: src/dbus-service/action.js:170
 msgctxt "checktext"
 msgid "suspend"
 msgstr "Pauzestand"
 
-#: src/dbus-service/action.js:152
+#: src/dbus-service/action.js:171
 msgctxt "checktext"
 msgid "shutdown"
 msgstr "afsluiten"
 
-#: src/dbus-service/action.js:153
+#: src/dbus-service/action.js:172
 msgctxt "checktext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:154
+#: src/dbus-service/action.js:173
 msgctxt "checktext"
 msgid "wakeup"
 msgstr ""
 
-#: src/dbus-service/action.js:160
+#: src/dbus-service/action.js:179
 msgctxt "untiltext"
 msgid "suspend and hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:161
+#: src/dbus-service/action.js:180
 msgctxt "untiltext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:162
+#: src/dbus-service/action.js:181
 msgctxt "untiltext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:163
+#: src/dbus-service/action.js:182
 msgctxt "untiltext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:164
+#: src/dbus-service/action.js:183
 msgctxt "untiltext"
 msgid "suspend"
 msgstr "Pauzestand"
 
-#: src/dbus-service/action.js:165
+#: src/dbus-service/action.js:184
 msgctxt "untiltext"
 msgid "shutdown"
 msgstr "afsluiten"
 
-#: src/dbus-service/action.js:166
+#: src/dbus-service/action.js:185
 msgctxt "untiltext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:167
+#: src/dbus-service/action.js:186
 msgctxt "untiltext"
 msgid "wakeup"
 msgstr ""
@@ -148,33 +148,13 @@ msgstr ""
 msgid "Privileged script installation required!"
 msgstr ""
 
-#: src/dbus-service/install.js:32 src/modules/install.js:32
-msgid "START"
-msgstr ""
-
-#: src/dbus-service/install.js:42 src/modules/install.js:42
-msgid "END"
-msgstr ""
-
-#: src/dbus-service/install.js:44 src/modules/install.js:44
-msgid "FAIL"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "install"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "uninstall"
-msgstr ""
-
-#: src/dbus-service/timer.js:108
+#: src/dbus-service/timer.js:113
 #, javascript-format
 msgctxt "StartSchedulePopup"
 msgid "%s in %s"
 msgstr "%s over %s"
 
-#: src/dbus-service/timer.js:112 src/modules/menu-item.js:400
+#: src/dbus-service/timer.js:117 src/modules/menu-item.js:393
 #: src/modules/schedule-info.js:123
 #, javascript-format
 msgid "%s hour"
@@ -182,33 +162,38 @@ msgid_plural "%s hours"
 msgstr[0] "%s uur"
 msgstr[1] "%s uren"
 
-#: src/dbus-service/timer.js:113 src/modules/menu-item.js:401
+#: src/dbus-service/timer.js:118 src/modules/menu-item.js:394
 #, javascript-format
 msgid "%s minute"
 msgid_plural "%s minutes"
 msgstr[0] "%s minuut"
 msgstr[1] "%s minuten"
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Confirmation canceled"
 msgstr ""
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Shutdown Timer stopped"
 msgstr "Afsluitklok is gestopt"
 
-#: src/dbus-service/timer.js:160
+#: src/dbus-service/timer.js:165
 #, javascript-format
 msgid "Waiting for %s confirmation"
 msgstr ""
 
-#: src/dbus-service/timer.js:210
+#: src/dbus-service/timer.js:215
 #, javascript-format
 msgctxt "CheckCommand"
 msgid "%s aborted (Code: %s)"
 msgstr ""
 
-#: src/dbus-service/timer.js:252 src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:223
+#, javascript-format
+msgid "%s is not supported!"
+msgstr ""
+
+#: src/dbus-service/timer.js:262 src/dbus-service/timer.js:320
 #, javascript-format
 msgctxt "Error"
 msgid ""
@@ -216,61 +201,81 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/dbus-service/timer.js:252
+#: src/dbus-service/timer.js:262
 msgid "Wake action failed!"
 msgstr ""
 
-#: src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:320
 msgid "Root mode protection failed!"
 msgstr ""
 
-#: src/modules/menu-item.js:92 src/modules/menu-item.js:298
+#: src/modules/install.js:32
+msgid "START"
+msgstr ""
+
+#: src/modules/install.js:42
+msgid "END"
+msgstr ""
+
+#: src/modules/install.js:44
+msgid "FAIL"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "install"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "uninstall"
+msgstr ""
+
+#: src/modules/menu-item.js:85 src/modules/menu-item.js:291
 msgid "Shutdown Timer"
 msgstr "Afsluitklok"
 
-#: src/modules/menu-item.js:124
+#: src/modules/menu-item.js:117
 msgid "Settings"
 msgstr "Voorkeuren"
 
-#: src/modules/menu-item.js:278
+#: src/modules/menu-item.js:271
 msgid "now"
 msgstr ""
 
-#: src/modules/menu-item.js:301
+#: src/modules/menu-item.js:294
 msgid "Check {checktext} for {durationString}"
 msgstr ""
 
-#: src/modules/menu-item.js:358 src/modules/menu-item.js:397
+#: src/modules/menu-item.js:351 src/modules/menu-item.js:390
 msgctxt "absolute time notation"
 msgid "%a, %R"
 msgstr ""
 
-#: src/modules/menu-item.js:361
+#: src/modules/menu-item.js:354
 #, javascript-format
 msgid "%s hr"
 msgid_plural "%s hrs"
 msgstr[0] "%s uur"
 msgstr[1] "%s uren"
 
-#: src/modules/menu-item.js:362 src/modules/schedule-info.js:129
+#: src/modules/menu-item.js:355 src/modules/schedule-info.js:129
 #, javascript-format
 msgid "%s min"
 msgid_plural "%s mins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/modules/menu-item.js:368
+#: src/modules/menu-item.js:361
 #, javascript-format
 msgid "%s (protect)"
 msgstr ""
 
-#: src/modules/menu-item.js:392
+#: src/modules/menu-item.js:385
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s at %s"
 msgstr ""
 
-#: src/modules/menu-item.js:393
+#: src/modules/menu-item.js:386
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s after %s"

--- a/po/pl.po
+++ b/po/pl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shutdown Timer GNOME Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-16 21:58+0200\n"
+"POT-Creation-Date: 2023-12-30 21:57+0100\n"
 "PO-Revision-Date: 2022-11-01 23:30+0100\n"
 "Last-Translator: Jakub Żywiec <jakub.zywiec@gmail.com>\n"
 "Language-Team: POLISH <jakub.zywiec@gmail.com>\n"
@@ -20,118 +20,118 @@ msgstr ""
 "X-Poedit-Basepath: ../../..\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: src/dbus-service/action.js:133
+#: src/dbus-service/action.js:152
 msgid "Suspend then Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:134
+#: src/dbus-service/action.js:153
 msgid "Hybrid Sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:135
+#: src/dbus-service/action.js:154
 msgid "Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:136
+#: src/dbus-service/action.js:155
 msgid "Halt"
 msgstr ""
 
-#: src/dbus-service/action.js:137
+#: src/dbus-service/action.js:156
 msgid "Suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:138
+#: src/dbus-service/action.js:157
 msgid "Power Off"
 msgstr ""
 
-#: src/dbus-service/action.js:139
+#: src/dbus-service/action.js:158
 msgid "Restart"
 msgstr ""
 
-#: src/dbus-service/action.js:140 src/ui/prefs.ui:239 src/ui/prefs.ui:442
+#: src/dbus-service/action.js:159 src/ui/prefs.ui:239 src/ui/prefs.ui:442
 msgid "Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:141
+#: src/dbus-service/action.js:160
 msgid "No Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:147
+#: src/dbus-service/action.js:166
 msgctxt "checktext"
 msgid "suspend then hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:148
+#: src/dbus-service/action.js:167
 msgctxt "checktext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:149
+#: src/dbus-service/action.js:168
 msgctxt "checktext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:150
+#: src/dbus-service/action.js:169
 msgctxt "checktext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:151
+#: src/dbus-service/action.js:170
 msgctxt "checktext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:152
+#: src/dbus-service/action.js:171
 msgctxt "checktext"
 msgid "shutdown"
 msgstr "wyłączenia"
 
-#: src/dbus-service/action.js:153
+#: src/dbus-service/action.js:172
 msgctxt "checktext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:154
+#: src/dbus-service/action.js:173
 msgctxt "checktext"
 msgid "wakeup"
 msgstr ""
 
-#: src/dbus-service/action.js:160
+#: src/dbus-service/action.js:179
 msgctxt "untiltext"
 msgid "suspend and hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:161
+#: src/dbus-service/action.js:180
 msgctxt "untiltext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:162
+#: src/dbus-service/action.js:181
 msgctxt "untiltext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:163
+#: src/dbus-service/action.js:182
 msgctxt "untiltext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:164
+#: src/dbus-service/action.js:183
 msgctxt "untiltext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:165
+#: src/dbus-service/action.js:184
 msgctxt "untiltext"
 msgid "shutdown"
 msgstr "wyłączenia"
 
-#: src/dbus-service/action.js:166
+#: src/dbus-service/action.js:185
 msgctxt "untiltext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:167
+#: src/dbus-service/action.js:186
 msgctxt "untiltext"
 msgid "wakeup"
 msgstr ""
@@ -148,33 +148,13 @@ msgstr ""
 msgid "Privileged script installation required!"
 msgstr ""
 
-#: src/dbus-service/install.js:32 src/modules/install.js:32
-msgid "START"
-msgstr ""
-
-#: src/dbus-service/install.js:42 src/modules/install.js:42
-msgid "END"
-msgstr ""
-
-#: src/dbus-service/install.js:44 src/modules/install.js:44
-msgid "FAIL"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "install"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "uninstall"
-msgstr ""
-
-#: src/dbus-service/timer.js:108
+#: src/dbus-service/timer.js:113
 #, javascript-format
 msgctxt "StartSchedulePopup"
 msgid "%s in %s"
 msgstr "%s za %s"
 
-#: src/dbus-service/timer.js:112 src/modules/menu-item.js:400
+#: src/dbus-service/timer.js:117 src/modules/menu-item.js:393
 #: src/modules/schedule-info.js:123
 #, javascript-format
 msgid "%s hour"
@@ -183,7 +163,7 @@ msgstr[0] "%s godzina"
 msgstr[1] "%s godziny"
 msgstr[2] "%s godzin"
 
-#: src/dbus-service/timer.js:113 src/modules/menu-item.js:401
+#: src/dbus-service/timer.js:118 src/modules/menu-item.js:394
 #, javascript-format
 msgid "%s minute"
 msgid_plural "%s minutes"
@@ -191,26 +171,31 @@ msgstr[0] "%s minuta"
 msgstr[1] "%s minuty"
 msgstr[2] "%s minut"
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Confirmation canceled"
 msgstr ""
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Shutdown Timer stopped"
 msgstr "Wyłącznik czasowy wstrzymany"
 
-#: src/dbus-service/timer.js:160
+#: src/dbus-service/timer.js:165
 #, javascript-format
 msgid "Waiting for %s confirmation"
 msgstr ""
 
-#: src/dbus-service/timer.js:210
+#: src/dbus-service/timer.js:215
 #, javascript-format
 msgctxt "CheckCommand"
 msgid "%s aborted (Code: %s)"
 msgstr ""
 
-#: src/dbus-service/timer.js:252 src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:223
+#, javascript-format
+msgid "%s is not supported!"
+msgstr ""
+
+#: src/dbus-service/timer.js:262 src/dbus-service/timer.js:320
 #, javascript-format
 msgctxt "Error"
 msgid ""
@@ -218,36 +203,56 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/dbus-service/timer.js:252
+#: src/dbus-service/timer.js:262
 msgid "Wake action failed!"
 msgstr ""
 
-#: src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:320
 msgid "Root mode protection failed!"
 msgstr ""
 
-#: src/modules/menu-item.js:92 src/modules/menu-item.js:298
+#: src/modules/install.js:32
+msgid "START"
+msgstr ""
+
+#: src/modules/install.js:42
+msgid "END"
+msgstr ""
+
+#: src/modules/install.js:44
+msgid "FAIL"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "install"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "uninstall"
+msgstr ""
+
+#: src/modules/menu-item.js:85 src/modules/menu-item.js:291
 msgid "Shutdown Timer"
 msgstr "Wyłącznik czasowy"
 
-#: src/modules/menu-item.js:124
+#: src/modules/menu-item.js:117
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: src/modules/menu-item.js:278
+#: src/modules/menu-item.js:271
 msgid "now"
 msgstr ""
 
-#: src/modules/menu-item.js:301
+#: src/modules/menu-item.js:294
 msgid "Check {checktext} for {durationString}"
 msgstr ""
 
-#: src/modules/menu-item.js:358 src/modules/menu-item.js:397
+#: src/modules/menu-item.js:351 src/modules/menu-item.js:390
 msgctxt "absolute time notation"
 msgid "%a, %R"
 msgstr ""
 
-#: src/modules/menu-item.js:361
+#: src/modules/menu-item.js:354
 #, javascript-format
 msgid "%s hr"
 msgid_plural "%s hrs"
@@ -255,7 +260,7 @@ msgstr[0] "%s godzina"
 msgstr[1] "%s godziny"
 msgstr[2] "%s godzin"
 
-#: src/modules/menu-item.js:362 src/modules/schedule-info.js:129
+#: src/modules/menu-item.js:355 src/modules/schedule-info.js:129
 #, javascript-format
 msgid "%s min"
 msgid_plural "%s mins"
@@ -263,18 +268,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/modules/menu-item.js:368
+#: src/modules/menu-item.js:361
 #, javascript-format
 msgid "%s (protect)"
 msgstr ""
 
-#: src/modules/menu-item.js:392
+#: src/modules/menu-item.js:385
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s at %s"
 msgstr ""
 
-#: src/modules/menu-item.js:393
+#: src/modules/menu-item.js:386
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s after %s"

--- a/po/pt.po
+++ b/po/pt.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shutdown Timer GNOME Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-16 21:58+0200\n"
+"POT-Creation-Date: 2023-12-30 21:57+0100\n"
 "PO-Revision-Date: 2022-04-07 22:13+0200\n"
 "Last-Translator: Daniel Neumann\n"
 "Language-Team: Roberto Alegro \"Kasama\"\n"
@@ -21,118 +21,118 @@ msgstr ""
 "X-Poedit-Basepath: ../../..\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: src/dbus-service/action.js:133
+#: src/dbus-service/action.js:152
 msgid "Suspend then Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:134
+#: src/dbus-service/action.js:153
 msgid "Hybrid Sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:135
+#: src/dbus-service/action.js:154
 msgid "Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:136
+#: src/dbus-service/action.js:155
 msgid "Halt"
 msgstr ""
 
-#: src/dbus-service/action.js:137
+#: src/dbus-service/action.js:156
 msgid "Suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:138
+#: src/dbus-service/action.js:157
 msgid "Power Off"
 msgstr ""
 
-#: src/dbus-service/action.js:139
+#: src/dbus-service/action.js:158
 msgid "Restart"
 msgstr ""
 
-#: src/dbus-service/action.js:140 src/ui/prefs.ui:239 src/ui/prefs.ui:442
+#: src/dbus-service/action.js:159 src/ui/prefs.ui:239 src/ui/prefs.ui:442
 msgid "Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:141
+#: src/dbus-service/action.js:160
 msgid "No Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:147
+#: src/dbus-service/action.js:166
 msgctxt "checktext"
 msgid "suspend then hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:148
+#: src/dbus-service/action.js:167
 msgctxt "checktext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:149
+#: src/dbus-service/action.js:168
 msgctxt "checktext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:150
+#: src/dbus-service/action.js:169
 msgctxt "checktext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:151
+#: src/dbus-service/action.js:170
 msgctxt "checktext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:152
+#: src/dbus-service/action.js:171
 msgctxt "checktext"
 msgid "shutdown"
 msgstr "desligamento"
 
-#: src/dbus-service/action.js:153
+#: src/dbus-service/action.js:172
 msgctxt "checktext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:154
+#: src/dbus-service/action.js:173
 msgctxt "checktext"
 msgid "wakeup"
 msgstr ""
 
-#: src/dbus-service/action.js:160
+#: src/dbus-service/action.js:179
 msgctxt "untiltext"
 msgid "suspend and hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:161
+#: src/dbus-service/action.js:180
 msgctxt "untiltext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:162
+#: src/dbus-service/action.js:181
 msgctxt "untiltext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:163
+#: src/dbus-service/action.js:182
 msgctxt "untiltext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:164
+#: src/dbus-service/action.js:183
 msgctxt "untiltext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:165
+#: src/dbus-service/action.js:184
 msgctxt "untiltext"
 msgid "shutdown"
 msgstr "desligamento"
 
-#: src/dbus-service/action.js:166
+#: src/dbus-service/action.js:185
 msgctxt "untiltext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:167
+#: src/dbus-service/action.js:186
 msgctxt "untiltext"
 msgid "wakeup"
 msgstr ""
@@ -149,33 +149,13 @@ msgstr ""
 msgid "Privileged script installation required!"
 msgstr ""
 
-#: src/dbus-service/install.js:32 src/modules/install.js:32
-msgid "START"
-msgstr ""
-
-#: src/dbus-service/install.js:42 src/modules/install.js:42
-msgid "END"
-msgstr ""
-
-#: src/dbus-service/install.js:44 src/modules/install.js:44
-msgid "FAIL"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "install"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "uninstall"
-msgstr ""
-
-#: src/dbus-service/timer.js:108
+#: src/dbus-service/timer.js:113
 #, javascript-format
 msgctxt "StartSchedulePopup"
 msgid "%s in %s"
 msgstr "%s em %s"
 
-#: src/dbus-service/timer.js:112 src/modules/menu-item.js:400
+#: src/dbus-service/timer.js:117 src/modules/menu-item.js:393
 #: src/modules/schedule-info.js:123
 #, javascript-format
 msgid "%s hour"
@@ -183,33 +163,38 @@ msgid_plural "%s hours"
 msgstr[0] "%s hora"
 msgstr[1] "%s horas"
 
-#: src/dbus-service/timer.js:113 src/modules/menu-item.js:401
+#: src/dbus-service/timer.js:118 src/modules/menu-item.js:394
 #, javascript-format
 msgid "%s minute"
 msgid_plural "%s minutes"
 msgstr[0] "%s minuto"
 msgstr[1] "%s minutos"
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Confirmation canceled"
 msgstr ""
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Shutdown Timer stopped"
 msgstr "Temporizador desativado"
 
-#: src/dbus-service/timer.js:160
+#: src/dbus-service/timer.js:165
 #, javascript-format
 msgid "Waiting for %s confirmation"
 msgstr ""
 
-#: src/dbus-service/timer.js:210
+#: src/dbus-service/timer.js:215
 #, javascript-format
 msgctxt "CheckCommand"
 msgid "%s aborted (Code: %s)"
 msgstr ""
 
-#: src/dbus-service/timer.js:252 src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:223
+#, javascript-format
+msgid "%s is not supported!"
+msgstr ""
+
+#: src/dbus-service/timer.js:262 src/dbus-service/timer.js:320
 #, javascript-format
 msgctxt "Error"
 msgid ""
@@ -217,61 +202,81 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/dbus-service/timer.js:252
+#: src/dbus-service/timer.js:262
 msgid "Wake action failed!"
 msgstr ""
 
-#: src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:320
 msgid "Root mode protection failed!"
 msgstr ""
 
-#: src/modules/menu-item.js:92 src/modules/menu-item.js:298
+#: src/modules/install.js:32
+msgid "START"
+msgstr ""
+
+#: src/modules/install.js:42
+msgid "END"
+msgstr ""
+
+#: src/modules/install.js:44
+msgid "FAIL"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "install"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "uninstall"
+msgstr ""
+
+#: src/modules/menu-item.js:85 src/modules/menu-item.js:291
 msgid "Shutdown Timer"
 msgstr "Temporizador de desligamento"
 
-#: src/modules/menu-item.js:124
+#: src/modules/menu-item.js:117
 msgid "Settings"
 msgstr "Configurações"
 
-#: src/modules/menu-item.js:278
+#: src/modules/menu-item.js:271
 msgid "now"
 msgstr ""
 
-#: src/modules/menu-item.js:301
+#: src/modules/menu-item.js:294
 msgid "Check {checktext} for {durationString}"
 msgstr ""
 
-#: src/modules/menu-item.js:358 src/modules/menu-item.js:397
+#: src/modules/menu-item.js:351 src/modules/menu-item.js:390
 msgctxt "absolute time notation"
 msgid "%a, %R"
 msgstr ""
 
-#: src/modules/menu-item.js:361
+#: src/modules/menu-item.js:354
 #, javascript-format
 msgid "%s hr"
 msgid_plural "%s hrs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/modules/menu-item.js:362 src/modules/schedule-info.js:129
+#: src/modules/menu-item.js:355 src/modules/schedule-info.js:129
 #, javascript-format
 msgid "%s min"
 msgid_plural "%s mins"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/modules/menu-item.js:368
+#: src/modules/menu-item.js:361
 #, javascript-format
 msgid "%s (protect)"
 msgstr ""
 
-#: src/modules/menu-item.js:392
+#: src/modules/menu-item.js:385
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s at %s"
 msgstr ""
 
-#: src/modules/menu-item.js:393
+#: src/modules/menu-item.js:386
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s after %s"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shutdown Timer GNOME Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-16 21:58+0200\n"
+"POT-Creation-Date: 2023-12-30 21:57+0100\n"
 "PO-Revision-Date: 2022-11-01 23:30+0100\n"
 "Last-Translator: Daniel Neumann\n"
 "Language-Team: Russian <LL@li.org>\n"
@@ -21,118 +21,118 @@ msgstr ""
 "X-Poedit-Basepath: ../../..\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: src/dbus-service/action.js:133
+#: src/dbus-service/action.js:152
 msgid "Suspend then Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:134
+#: src/dbus-service/action.js:153
 msgid "Hybrid Sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:135
+#: src/dbus-service/action.js:154
 msgid "Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:136
+#: src/dbus-service/action.js:155
 msgid "Halt"
 msgstr ""
 
-#: src/dbus-service/action.js:137
+#: src/dbus-service/action.js:156
 msgid "Suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:138
+#: src/dbus-service/action.js:157
 msgid "Power Off"
 msgstr ""
 
-#: src/dbus-service/action.js:139
+#: src/dbus-service/action.js:158
 msgid "Restart"
 msgstr ""
 
-#: src/dbus-service/action.js:140 src/ui/prefs.ui:239 src/ui/prefs.ui:442
+#: src/dbus-service/action.js:159 src/ui/prefs.ui:239 src/ui/prefs.ui:442
 msgid "Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:141
+#: src/dbus-service/action.js:160
 msgid "No Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:147
+#: src/dbus-service/action.js:166
 msgctxt "checktext"
 msgid "suspend then hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:148
+#: src/dbus-service/action.js:167
 msgctxt "checktext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:149
+#: src/dbus-service/action.js:168
 msgctxt "checktext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:150
+#: src/dbus-service/action.js:169
 msgctxt "checktext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:151
+#: src/dbus-service/action.js:170
 msgctxt "checktext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:152
+#: src/dbus-service/action.js:171
 msgctxt "checktext"
 msgid "shutdown"
 msgstr "выключения"
 
-#: src/dbus-service/action.js:153
+#: src/dbus-service/action.js:172
 msgctxt "checktext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:154
+#: src/dbus-service/action.js:173
 msgctxt "checktext"
 msgid "wakeup"
 msgstr ""
 
-#: src/dbus-service/action.js:160
+#: src/dbus-service/action.js:179
 msgctxt "untiltext"
 msgid "suspend and hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:161
+#: src/dbus-service/action.js:180
 msgctxt "untiltext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:162
+#: src/dbus-service/action.js:181
 msgctxt "untiltext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:163
+#: src/dbus-service/action.js:182
 msgctxt "untiltext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:164
+#: src/dbus-service/action.js:183
 msgctxt "untiltext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:165
+#: src/dbus-service/action.js:184
 msgctxt "untiltext"
 msgid "shutdown"
 msgstr "выключения"
 
-#: src/dbus-service/action.js:166
+#: src/dbus-service/action.js:185
 msgctxt "untiltext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:167
+#: src/dbus-service/action.js:186
 msgctxt "untiltext"
 msgid "wakeup"
 msgstr ""
@@ -149,33 +149,13 @@ msgstr ""
 msgid "Privileged script installation required!"
 msgstr ""
 
-#: src/dbus-service/install.js:32 src/modules/install.js:32
-msgid "START"
-msgstr ""
-
-#: src/dbus-service/install.js:42 src/modules/install.js:42
-msgid "END"
-msgstr ""
-
-#: src/dbus-service/install.js:44 src/modules/install.js:44
-msgid "FAIL"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "install"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "uninstall"
-msgstr ""
-
-#: src/dbus-service/timer.js:108
+#: src/dbus-service/timer.js:113
 #, javascript-format
 msgctxt "StartSchedulePopup"
 msgid "%s in %s"
 msgstr "%s через %s"
 
-#: src/dbus-service/timer.js:112 src/modules/menu-item.js:400
+#: src/dbus-service/timer.js:117 src/modules/menu-item.js:393
 #: src/modules/schedule-info.js:123
 #, javascript-format
 msgid "%s hour"
@@ -184,7 +164,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/dbus-service/timer.js:113 src/modules/menu-item.js:401
+#: src/dbus-service/timer.js:118 src/modules/menu-item.js:394
 #, javascript-format
 msgid "%s minute"
 msgid_plural "%s minutes"
@@ -192,26 +172,31 @@ msgstr[0] "%s мин."
 msgstr[1] "%s мин."
 msgstr[2] "%s мин."
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Confirmation canceled"
 msgstr ""
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Shutdown Timer stopped"
 msgstr "Таймер выключения остановлен"
 
-#: src/dbus-service/timer.js:160
+#: src/dbus-service/timer.js:165
 #, javascript-format
 msgid "Waiting for %s confirmation"
 msgstr ""
 
-#: src/dbus-service/timer.js:210
+#: src/dbus-service/timer.js:215
 #, javascript-format
 msgctxt "CheckCommand"
 msgid "%s aborted (Code: %s)"
 msgstr ""
 
-#: src/dbus-service/timer.js:252 src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:223
+#, javascript-format
+msgid "%s is not supported!"
+msgstr ""
+
+#: src/dbus-service/timer.js:262 src/dbus-service/timer.js:320
 #, javascript-format
 msgctxt "Error"
 msgid ""
@@ -219,36 +204,56 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/dbus-service/timer.js:252
+#: src/dbus-service/timer.js:262
 msgid "Wake action failed!"
 msgstr ""
 
-#: src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:320
 msgid "Root mode protection failed!"
 msgstr ""
 
-#: src/modules/menu-item.js:92 src/modules/menu-item.js:298
+#: src/modules/install.js:32
+msgid "START"
+msgstr ""
+
+#: src/modules/install.js:42
+msgid "END"
+msgstr ""
+
+#: src/modules/install.js:44
+msgid "FAIL"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "install"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "uninstall"
+msgstr ""
+
+#: src/modules/menu-item.js:85 src/modules/menu-item.js:291
 msgid "Shutdown Timer"
 msgstr "Таймер выключения"
 
-#: src/modules/menu-item.js:124
+#: src/modules/menu-item.js:117
 msgid "Settings"
 msgstr ""
 
-#: src/modules/menu-item.js:278
+#: src/modules/menu-item.js:271
 msgid "now"
 msgstr ""
 
-#: src/modules/menu-item.js:301
+#: src/modules/menu-item.js:294
 msgid "Check {checktext} for {durationString}"
 msgstr ""
 
-#: src/modules/menu-item.js:358 src/modules/menu-item.js:397
+#: src/modules/menu-item.js:351 src/modules/menu-item.js:390
 msgctxt "absolute time notation"
 msgid "%a, %R"
 msgstr ""
 
-#: src/modules/menu-item.js:361
+#: src/modules/menu-item.js:354
 #, javascript-format
 msgid "%s hr"
 msgid_plural "%s hrs"
@@ -256,7 +261,7 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/modules/menu-item.js:362 src/modules/schedule-info.js:129
+#: src/modules/menu-item.js:355 src/modules/schedule-info.js:129
 #, javascript-format
 msgid "%s min"
 msgid_plural "%s mins"
@@ -264,18 +269,18 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/modules/menu-item.js:368
+#: src/modules/menu-item.js:361
 #, javascript-format
 msgid "%s (protect)"
 msgstr ""
 
-#: src/modules/menu-item.js:392
+#: src/modules/menu-item.js:385
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s at %s"
 msgstr ""
 
-#: src/modules/menu-item.js:393
+#: src/modules/menu-item.js:386
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s after %s"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shutdown Timer GNOME Shell Extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-09-16 21:58+0200\n"
+"POT-Creation-Date: 2023-12-30 21:57+0100\n"
 "PO-Revision-Date: 2022-04-07 22:08+0200\n"
 "Last-Translator: 绿色圣光 <lishaohui.qd@163.com>\n"
 "Language-Team: Chinese (Simplified) <>\n"
@@ -20,118 +20,118 @@ msgstr ""
 "X-Poedit-Basepath: ../../..\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: src/dbus-service/action.js:133
+#: src/dbus-service/action.js:152
 msgid "Suspend then Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:134
+#: src/dbus-service/action.js:153
 msgid "Hybrid Sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:135
+#: src/dbus-service/action.js:154
 msgid "Hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:136
+#: src/dbus-service/action.js:155
 msgid "Halt"
 msgstr ""
 
-#: src/dbus-service/action.js:137
+#: src/dbus-service/action.js:156
 msgid "Suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:138
+#: src/dbus-service/action.js:157
 msgid "Power Off"
 msgstr ""
 
-#: src/dbus-service/action.js:139
+#: src/dbus-service/action.js:158
 msgid "Restart"
 msgstr ""
 
-#: src/dbus-service/action.js:140 src/ui/prefs.ui:239 src/ui/prefs.ui:442
+#: src/dbus-service/action.js:159 src/ui/prefs.ui:239 src/ui/prefs.ui:442
 msgid "Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:141
+#: src/dbus-service/action.js:160
 msgid "No Wake"
 msgstr ""
 
-#: src/dbus-service/action.js:147
+#: src/dbus-service/action.js:166
 msgctxt "checktext"
 msgid "suspend then hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:148
+#: src/dbus-service/action.js:167
 msgctxt "checktext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:149
+#: src/dbus-service/action.js:168
 msgctxt "checktext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:150
+#: src/dbus-service/action.js:169
 msgctxt "checktext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:151
+#: src/dbus-service/action.js:170
 msgctxt "checktext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:152
+#: src/dbus-service/action.js:171
 msgctxt "checktext"
 msgid "shutdown"
 msgstr "关机"
 
-#: src/dbus-service/action.js:153
+#: src/dbus-service/action.js:172
 msgctxt "checktext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:154
+#: src/dbus-service/action.js:173
 msgctxt "checktext"
 msgid "wakeup"
 msgstr ""
 
-#: src/dbus-service/action.js:160
+#: src/dbus-service/action.js:179
 msgctxt "untiltext"
 msgid "suspend and hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:161
+#: src/dbus-service/action.js:180
 msgctxt "untiltext"
 msgid "hybrid sleep"
 msgstr ""
 
-#: src/dbus-service/action.js:162
+#: src/dbus-service/action.js:181
 msgctxt "untiltext"
 msgid "hibernate"
 msgstr ""
 
-#: src/dbus-service/action.js:163
+#: src/dbus-service/action.js:182
 msgctxt "untiltext"
 msgid "halt"
 msgstr ""
 
-#: src/dbus-service/action.js:164
+#: src/dbus-service/action.js:183
 msgctxt "untiltext"
 msgid "suspend"
 msgstr ""
 
-#: src/dbus-service/action.js:165
+#: src/dbus-service/action.js:184
 msgctxt "untiltext"
 msgid "shutdown"
 msgstr "关机"
 
-#: src/dbus-service/action.js:166
+#: src/dbus-service/action.js:185
 msgctxt "untiltext"
 msgid "reboot"
 msgstr ""
 
-#: src/dbus-service/action.js:167
+#: src/dbus-service/action.js:186
 msgctxt "untiltext"
 msgid "wakeup"
 msgstr ""
@@ -148,65 +148,50 @@ msgstr ""
 msgid "Privileged script installation required!"
 msgstr ""
 
-#: src/dbus-service/install.js:32 src/modules/install.js:32
-msgid "START"
-msgstr ""
-
-#: src/dbus-service/install.js:42 src/modules/install.js:42
-msgid "END"
-msgstr ""
-
-#: src/dbus-service/install.js:44 src/modules/install.js:44
-msgid "FAIL"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "install"
-msgstr ""
-
-#: src/dbus-service/install.js:62 src/modules/install.js:62
-msgid "uninstall"
-msgstr ""
-
-#: src/dbus-service/timer.js:108
+#: src/dbus-service/timer.js:113
 #, javascript-format
 msgctxt "StartSchedulePopup"
 msgid "%s in %s"
 msgstr ""
 
-#: src/dbus-service/timer.js:112 src/modules/menu-item.js:400
+#: src/dbus-service/timer.js:117 src/modules/menu-item.js:393
 #: src/modules/schedule-info.js:123
 #, javascript-format
 msgid "%s hour"
 msgid_plural "%s hours"
 msgstr[0] "%s時"
 
-#: src/dbus-service/timer.js:113 src/modules/menu-item.js:401
+#: src/dbus-service/timer.js:118 src/modules/menu-item.js:394
 #, javascript-format
 msgid "%s minute"
 msgid_plural "%s minutes"
 msgstr[0] "%s分"
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Confirmation canceled"
 msgstr ""
 
-#: src/dbus-service/timer.js:139
+#: src/dbus-service/timer.js:144
 msgid "Shutdown Timer stopped"
 msgstr "已取消定时关机"
 
-#: src/dbus-service/timer.js:160
+#: src/dbus-service/timer.js:165
 #, javascript-format
 msgid "Waiting for %s confirmation"
 msgstr ""
 
-#: src/dbus-service/timer.js:210
+#: src/dbus-service/timer.js:215
 #, javascript-format
 msgctxt "CheckCommand"
 msgid "%s aborted (Code: %s)"
 msgstr ""
 
-#: src/dbus-service/timer.js:252 src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:223
+#, javascript-format
+msgid "%s is not supported!"
+msgstr ""
+
+#: src/dbus-service/timer.js:262 src/dbus-service/timer.js:320
 #, javascript-format
 msgctxt "Error"
 msgid ""
@@ -214,59 +199,79 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/dbus-service/timer.js:252
+#: src/dbus-service/timer.js:262
 msgid "Wake action failed!"
 msgstr ""
 
-#: src/dbus-service/timer.js:310
+#: src/dbus-service/timer.js:320
 msgid "Root mode protection failed!"
 msgstr ""
 
-#: src/modules/menu-item.js:92 src/modules/menu-item.js:298
+#: src/modules/install.js:32
+msgid "START"
+msgstr ""
+
+#: src/modules/install.js:42
+msgid "END"
+msgstr ""
+
+#: src/modules/install.js:44
+msgid "FAIL"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "install"
+msgstr ""
+
+#: src/modules/install.js:62
+msgid "uninstall"
+msgstr ""
+
+#: src/modules/menu-item.js:85 src/modules/menu-item.js:291
 msgid "Shutdown Timer"
 msgstr "定时关机"
 
-#: src/modules/menu-item.js:124
+#: src/modules/menu-item.js:117
 msgid "Settings"
 msgstr "设置"
 
-#: src/modules/menu-item.js:278
+#: src/modules/menu-item.js:271
 msgid "now"
 msgstr ""
 
-#: src/modules/menu-item.js:301
+#: src/modules/menu-item.js:294
 msgid "Check {checktext} for {durationString}"
 msgstr ""
 
-#: src/modules/menu-item.js:358 src/modules/menu-item.js:397
+#: src/modules/menu-item.js:351 src/modules/menu-item.js:390
 msgctxt "absolute time notation"
 msgid "%a, %R"
 msgstr ""
 
-#: src/modules/menu-item.js:361
+#: src/modules/menu-item.js:354
 #, javascript-format
 msgid "%s hr"
 msgid_plural "%s hrs"
 msgstr[0] "%s時"
 
-#: src/modules/menu-item.js:362 src/modules/schedule-info.js:129
+#: src/modules/menu-item.js:355 src/modules/schedule-info.js:129
 #, javascript-format
 msgid "%s min"
 msgid_plural "%s mins"
 msgstr[0] "%s分"
 
-#: src/modules/menu-item.js:368
+#: src/modules/menu-item.js:361
 #, javascript-format
 msgid "%s (protect)"
 msgstr ""
 
-#: src/modules/menu-item.js:392
+#: src/modules/menu-item.js:385
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s at %s"
 msgstr ""
 
-#: src/modules/menu-item.js:393
+#: src/modules/menu-item.js:386
 #, javascript-format
 msgctxt "WakeButtonText"
 msgid "%s after %s"

--- a/src/dbus-interfaces/org.gnome.Shell.Extensions.ShutdownTimer.Local.xml
+++ b/src/dbus-interfaces/org.gnome.Shell.Extensions.ShutdownTimer.Local.xml
@@ -3,7 +3,7 @@
 	SPDX-License-Identifier: GPL-3.0-or-later
 -->
 <node>
- <interface name="org.gnome.shell.Extensions.ShutdownTimer">
+ <interface name="org.gnome.shell.Extensions.ShutdownTimer.Local">
   <method name="ScheduleShutdown">
    <arg type="b" direction="in" name="shutdown"/>
    <arg type="s" direction="in" name="action"/>

--- a/src/dbus-service/shutdown-timer-dbus.js
+++ b/src/dbus-service/shutdown-timer-dbus.js
@@ -7,7 +7,7 @@ import GLib from 'gi://GLib';
 import { loadInterfaceXML, logDebug } from '../modules/util.js';
 import { Timer } from './timer.js';
 
-export const ShutdownTimerName = 'org.gnome.Shell.Extensions.ShutdownTimer';
+export const ShutdownTimerName = 'org.gnome.Shell.Extensions.ShutdownTimer.Local';
 export const ShutdownTimerObjectPath =
   '/org/gnome/Shell/Extensions/ShutdownTimer';
 export const ShutdownTimerIface = await loadInterfaceXML(ShutdownTimerName);

--- a/src/dbus-service/shutdown-timer-dbus.js
+++ b/src/dbus-service/shutdown-timer-dbus.js
@@ -7,7 +7,8 @@ import GLib from 'gi://GLib';
 import { loadInterfaceXML, logDebug } from '../modules/util.js';
 import { Timer } from './timer.js';
 
-export const ShutdownTimerName = 'org.gnome.Shell.Extensions.ShutdownTimer.Local';
+export const ShutdownTimerName =
+  'org.gnome.Shell.Extensions.ShutdownTimer.Local';
 export const ShutdownTimerObjectPath =
   '/org/gnome/Shell/Extensions/ShutdownTimer';
 export const ShutdownTimerIface = await loadInterfaceXML(ShutdownTimerName);

--- a/src/dbus-service/timer.js
+++ b/src/dbus-service/timer.js
@@ -18,7 +18,12 @@ import {
   getShutdownScheduleFromSettings,
   getSliderMinutesFromSettings,
 } from '../modules/schedule-info.js';
-import { actionLabel, Action, mapLegacyAction } from './action.js';
+import {
+  actionLabel,
+  Action,
+  mapLegacyAction,
+  UnsupportedActionError,
+} from './action.js';
 
 const Signals = imports.signals;
 
@@ -176,7 +181,7 @@ export class Timer {
         this._updateRootModeProtection(),
         // Check succeeded: do shutdown
         this._action.shutdownAction(
-          this.info.internalShutdown.mode,
+          internal.mode,
           this._settings.get_boolean('show-end-session-dialog-value')
         ),
       ]);
@@ -211,6 +216,11 @@ export class Timer {
             actionLabel(internal.mode),
             code
           )
+        );
+      } else if (err instanceof UnsupportedActionError) {
+        this.emit(
+          'message',
+          _('%s is not supported!').format(actionLabel(internal.mode))
         );
       }
       await this.toggleShutdown(false);

--- a/src/modules/menu-item.js
+++ b/src/modules/menu-item.js
@@ -443,7 +443,9 @@ export const ShutdownTimerSystemIndicator = GObject.registerClass(
       const proxyCancel = new Gio.Cancellable();
       this._sdtProxy = null;
       this._initProxy(item, this._textbox, infoFetcher, proxyCancel).catch(
-        err => console.error('[sdt-proxy]', err)
+        err => {
+          if (!proxyCancel.is_cancelled()) console.error('[sdt-proxy]', err);
+        }
       );
       // React to changes in external shutdown and wake schedule
       infoFetcher.connect('changed', () => this._syncShutdownInfo());

--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -32,8 +32,7 @@ export async function proxyPromise(
         await loadInterfaceXML(ProxyTypeOrName, cancellable)
       );
     } catch (err) {
-      console.error('[proxyPromise]', err);
-      return null;
+      throw new Error('Failed to load proxy interface!', { cause: err });
     }
   }
   const p = await new Promise((resolve, reject) => {
@@ -165,14 +164,15 @@ export async function loadInterfaceXML(iface, cancellable = null) {
     try {
       return await readFileAsync(file, cancellable);
     } catch (err) {
-      if (cancellable && cancellable.is_cancelled()) {
-        throw err;
-      }
       return '';
     }
   });
   for await (const xml of readPromises) {
     if (xml) return xml;
   }
-  throw new Error(`Failed to load D-Bus interface ${iface}'`);
+  throw new Error(
+    `Failed to load D-Bus interface '${iface}'${
+      cancellable && cancellable.is_cancelled() ? ' (canceled)' : ''
+    }`
+  );
 }


### PR DESCRIPTION
https://github.com/Deminder/ShutdownTimer/commit/b48ea3321de4ed35276de0328ead1a05221a8ec3 has added more shutdown actions.
```
PowerOff
Reboot
Suspend
SuspendThenHibernate
Hibernate
HybridSleep
Halt
```

Now, actions which are not supported on a particular system are hidden in the preferences window. 

Closes: https://github.com/Deminder/ShutdownTimer/issues/7