### PR TITLE
timer: Fix timer behavior for suspend

### DIFF
--- a/src/dbus-interfaces/org.gnome.SessionManager.xml
+++ b/src/dbus-interfaces/org.gnome.SessionManager.xml
@@ -1,0 +1,20 @@
+<!--
+	SPDX-FileCopyrightText: 2024 dbus.gnome.org
+	SPDX-License-Identifier: GPL-3.0-or-later
+-->
+<node>
+  <interface name="org.gnome.SessionManager">
+    <method name="Inhibit">
+      <arg type="s" name="app_id" direction="in"/>
+      <arg type="u" name="toplevel_xid" direction="in"/>
+      <arg type="s" name="reason" direction="in"/>
+      <arg type="u" name="flags" direction="in"/>
+      <arg type="u" name="inhibit_cookie" direction="out"/>
+    </method>
+    <method name="Uninhibit">
+      <arg type="u" name="inhibit_cookie" direction="in"/>
+    </method>
+    <method name="Shutdown"/>
+    <method name="Reboot"/>
+  </interface>
+</node>

--- a/src/dbus-service/check-command.js
+++ b/src/dbus-service/check-command.js
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Deminder <tremminder@gmail.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import GLib from 'gi://GLib';
 import Gio from 'gi://Gio';
 import { gettext as _ } from '../modules/translation.js';
 
@@ -64,8 +65,11 @@ export class CheckCommand {
       console.error('[check-tick]', err);
     }
     try {
-      await Control.execCheck(['sleep', '30'], this.#checkCancel, false);
-      await this.continueTick(tickAsync);
+      await Control.sleepUntilDeadline(
+        GLib.DateTime.new_now_utc().to_unix() + 30,
+        this.#checkCancel
+      );
+      await this.#continueTick(tickAsync);
     } catch {
       logDebug('[check-tick] Done');
     }

--- a/src/dbus-service/timer.js
+++ b/src/dbus-service/timer.js
@@ -223,8 +223,8 @@ export class Timer {
           _('%s is not supported!').format(actionLabel(internal.mode))
         );
       }
-      await this.toggleShutdown(false);
     }
+    await this.toggleShutdown(false);
   }
 
   async executeActionDelayed() {
@@ -234,10 +234,9 @@ export class Timer {
       logDebug(`Started delayed action: ${internal.minutes}min remaining`);
       try {
         this._timerCancellable = new Gio.Cancellable();
-        await Control.execCheck(
-          ['sleep', `${secs}`],
-          this._timerCancellable,
-          false
+        await Control.sleepUntilDeadline(
+          internal.deadline,
+          this._timerCancellable
         );
         this._timerCancellable = null;
       } catch {
@@ -282,6 +281,11 @@ export class Timer {
             )
         : -1
     );
+    if (shutdown) {
+      await this._action.inhibitSuspend();
+    } else {
+      await this._action.uninhibitSuspend();
+    }
     if (this._settings.get_boolean('auto-wake-value')) {
       await this.toggleWake(shutdown);
     }


### PR DESCRIPTION
Now, the expiration of the scheduled deadline is checked periodically every second; avoiding problems with monotonic time keeping. Additionally, suspend is inhibited while a shutdown action is scheduled.

Fixes #21